### PR TITLE
Handle af1c1onados playlist catalog structure changes

### DIFF
--- a/plugins/af1c1onados_plugin.py
+++ b/plugins/af1c1onados_plugin.py
@@ -5,10 +5,13 @@ http://ip:port/af1c1onados
 '''
 __author__ = 'HTTPAceProxy'
 
+import difflib
+import re
 import requests
 import logging
 import traceback
 import time
+import unicodedata
 import zlib
 from urllib3.packages.six.moves.urllib.parse import urlparse, quote, unquote
 from urllib3.packages.six import ensure_str, ensure_binary, ensure_text
@@ -25,7 +28,15 @@ class Af1c1onados(object):
         self.AceProxy = AceProxy
         self.picons = self.channels = self.playlist = self.etag = None
         self.playlisttime = time.time()
-        self.headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'}
+        self.catalogindex = None
+        self.catalogindextime = 0
+        self.headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.9',
+            'Cache-Control': 'no-cache',
+            'Pragma': 'no-cache'
+        }
         self.logger = logging.getLogger('Af1c1onados')
         
         # Initial parse
@@ -36,14 +47,100 @@ class Af1c1onados(object):
             schedule(config.updateevery * 60, self.Playlistparser)
 
     def _normalize_playlist_url(self, url):
-        url = config.urlaliases.get(url, url)
         parsed = urlparse(url)
         if parsed.netloc == 'github.com' and '/blob/' in parsed.path:
             return 'https://raw.githubusercontent.com%s' % parsed.path.replace('/blob/', '/', 1)
         return url
 
-    def _fetch_playlist_data(self, url):
+    def _is_shortener_url(self, url):
+        return urlparse(url).netloc in ('cutt.ly', 'urlfy.org', 'n9.cl', 'smurl.es')
+
+    def _normalize_catalog_name(self, value, compact=False):
+        normalized = unicodedata.normalize('NFKD', ensure_text(value)).encode('ascii', 'ignore').decode('ascii').lower()
+        normalized = re.sub(r'^\d+(?:\.\d+)?\s*', '', normalized)
+        normalized = re.sub(r'\.w3u$', '', normalized)
+        normalized = normalized.replace('#', ' ')
+        aliases = {'m': 'movistar', 'tennis': 'tenis', 'us': 'usa'}
+        skip_tokens = ('sport', 'sports', 'tv', 'channel', 'hd', 'newloop') if compact else ()
+        tokens = []
+        for token in re.split(r'[^a-z0-9]+', normalized):
+            if not token:
+                continue
+            token = aliases.get(token, token)
+            if token in skip_tokens:
+                continue
+            tokens.append(token)
+        return ' '.join(tokens)
+
+    def _load_catalog_index(self):
+        if self.catalogindex and (time.time() - self.catalogindextime) < 3600:
+            return self.catalogindex
+
+        response = requests.get(config.catalogtreeurl, headers=self.headers, proxies=config.proxies, timeout=30)
+        response.raise_for_status()
+
+        catalogindex = []
+        for item in response.json().get('tree', []):
+            path = item.get('path')
+            if item.get('type') != 'blob' or not path or path == 'AcEStREAM iDs.w3u':
+                continue
+
+            catalogindex.append({
+                'path': path,
+                'url': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/main/%s' % quote(ensure_str(path), '/'),
+                'strict': self._normalize_catalog_name(path),
+                'compact': self._normalize_catalog_name(path, compact=True)
+            })
+
+        self.catalogindex = catalogindex
+        self.catalogindextime = time.time()
+        return self.catalogindex
+
+    def _guess_catalog_url(self, group_name):
+        strict_name = self._normalize_catalog_name(group_name)
+        compact_name = self._normalize_catalog_name(group_name, compact=True)
+        best = second = (0, None)
+
+        for entry in self._load_catalog_index():
+            scores = []
+            if strict_name and entry['strict']:
+                scores.append(difflib.SequenceMatcher(None, strict_name, entry['strict']).ratio())
+            if compact_name and entry['compact']:
+                scores.append(difflib.SequenceMatcher(None, compact_name, entry['compact']).ratio())
+
+            score = max(scores) if scores else 0
+            if score > best[0]:
+                second = best
+                best = (score, entry)
+            elif score > second[0]:
+                second = (score, entry)
+
+        if best[0] >= 0.75 and (best[0] - second[0]) >= 0.05:
+            self.logger.warning('Resolved subgroup %s via catalog tree: %s' % (group_name, best[1]['path']))
+            return best[1]['url']
+        return None
+
+    def _resolve_shortener_url(self, url, group_name=None):
+        try:
+            response = requests.get(url, headers=self.headers, proxies=config.proxies, timeout=30, allow_redirects=False)
+            location = response.headers.get('Location')
+            if 300 <= response.status_code < 400 and location:
+                return self._normalize_playlist_url(location)
+        except Exception as e:
+            self.logger.warning('Shortener resolution failed for %s: %s' % (url, repr(e)))
+
+        if group_name:
+            guessed_url = self._guess_catalog_url(group_name)
+            if guessed_url:
+                return guessed_url
+
+        return self._normalize_playlist_url(url)
+
+    def _fetch_playlist_data(self, url, group_name=None):
         normalized_url = self._normalize_playlist_url(url)
+        if self._is_shortener_url(normalized_url):
+            normalized_url = self._resolve_shortener_url(normalized_url, group_name=group_name)
+
         self.logger.info('Fetching playlist from %s' % normalized_url)
         response = requests.get(normalized_url, headers=self.headers, proxies=config.proxies, timeout=30)
         redirected_url = self._normalize_playlist_url(response.url)
@@ -80,7 +177,7 @@ class Af1c1onados(object):
                 continue
 
             try:
-                group_data, fetched_url = self._fetch_playlist_data(group_url)
+                group_data, fetched_url = self._fetch_playlist_data(group_url, group_name=group_name)
             except Exception as e:
                 self.logger.error('Error fetching subgroup %s from %s: %s' % (group_name, normalized_url, repr(e)))
                 continue

--- a/plugins/af1c1onados_plugin.py
+++ b/plugins/af1c1onados_plugin.py
@@ -53,7 +53,10 @@ class Af1c1onados(object):
         return url
 
     def _is_shortener_url(self, url):
-        return urlparse(url).netloc in ('cutt.ly', 'urlfy.org', 'n9.cl', 'smurl.es')
+        hostname = urlparse(url).netloc.lower()
+        if hostname.startswith('www.'):
+            hostname = hostname[4:]
+        return hostname in ('cutt.ly', 'urlfy.org', 'n9.cl', 'smurl.es')
 
     def _normalize_catalog_name(self, value, compact=False):
         normalized = unicodedata.normalize('NFKD', ensure_text(value)).encode('ascii', 'ignore').decode('ascii').lower()
@@ -122,10 +125,18 @@ class Af1c1onados(object):
 
     def _resolve_shortener_url(self, url, group_name=None):
         try:
-            response = requests.get(url, headers=self.headers, proxies=config.proxies, timeout=30, allow_redirects=False)
-            location = response.headers.get('Location')
-            if 300 <= response.status_code < 400 and location:
-                return self._normalize_playlist_url(location)
+            current_url = url
+            for _ in range(5):
+                response = requests.get(current_url, headers=self.headers, proxies=config.proxies, timeout=30, allow_redirects=False)
+                location = response.headers.get('Location')
+                if 300 <= response.status_code < 400 and location:
+                    current_url = self._normalize_playlist_url(location)
+                    if not self._is_shortener_url(current_url):
+                        return current_url
+                    continue
+                response.raise_for_status()
+                break
+            return self._normalize_playlist_url(current_url)
         except Exception as e:
             self.logger.warning('Shortener resolution failed for %s: %s' % (url, repr(e)))
 

--- a/plugins/af1c1onados_plugin.py
+++ b/plugins/af1c1onados_plugin.py
@@ -36,6 +36,7 @@ class Af1c1onados(object):
             schedule(config.updateevery * 60, self.Playlistparser)
 
     def _normalize_playlist_url(self, url):
+        url = config.urlaliases.get(url, url)
         parsed = urlparse(url)
         if parsed.netloc == 'github.com' and '/blob/' in parsed.path:
             return 'https://raw.githubusercontent.com%s' % parsed.path.replace('/blob/', '/', 1)

--- a/plugins/af1c1onados_plugin.py
+++ b/plugins/af1c1onados_plugin.py
@@ -35,24 +35,72 @@ class Af1c1onados(object):
         if config.updateevery:
             schedule(config.updateevery * 60, self.Playlistparser)
 
+    def _normalize_playlist_url(self, url):
+        parsed = urlparse(url)
+        if parsed.netloc == 'github.com' and '/blob/' in parsed.path:
+            return 'https://raw.githubusercontent.com%s' % parsed.path.replace('/blob/', '/', 1)
+        return url
+
+    def _fetch_playlist_data(self, url):
+        normalized_url = self._normalize_playlist_url(url)
+        self.logger.info('Fetching playlist from %s' % normalized_url)
+        response = requests.get(normalized_url, headers=self.headers, proxies=config.proxies, timeout=30)
+        redirected_url = self._normalize_playlist_url(response.url)
+        if redirected_url != response.url and redirected_url != normalized_url:
+            self.logger.info('Refetching redirected playlist from %s' % redirected_url)
+            response = requests.get(redirected_url, headers=self.headers, proxies=config.proxies, timeout=30)
+            normalized_url = redirected_url
+        response.raise_for_status()
+        return response.json(), normalized_url
+
+    def _collect_station_groups(self, data, visited=None, fallback_group=None):
+        if visited is None:
+            visited = set()
+
+        station_groups = []
+        stations = data.get('stations', [])
+        if stations:
+            station_groups.append((data.get('name') or fallback_group or 'Others', stations))
+
+        for group in data.get('groups', []):
+            group_name = group.get('name') or fallback_group or 'Others'
+            stations = group.get('stations', [])
+            if stations:
+                station_groups.append((group_name, stations))
+                continue
+
+            group_url = group.get('url')
+            if not group_url:
+                continue
+
+            normalized_url = self._normalize_playlist_url(group_url)
+            if normalized_url in visited:
+                self.logger.warning('Skipping already fetched playlist %s' % normalized_url)
+                continue
+
+            try:
+                group_data, fetched_url = self._fetch_playlist_data(group_url)
+            except Exception as e:
+                self.logger.error('Error fetching subgroup %s from %s: %s' % (group_name, normalized_url, repr(e)))
+                continue
+
+            visited.add(normalized_url)
+            visited.add(fetched_url)
+            station_groups.extend(self._collect_station_groups(group_data, visited=visited, fallback_group=group_name))
+
+        return station_groups
+
     def Playlistparser(self):
         try:
-            self.logger.info('Fetching playlist from %s' % config.url)
-            r = requests.get(config.url, headers=self.headers, proxies=config.proxies, timeout=30)
-            r.raise_for_status()
-            
-            data = r.json()
-            
+            data, normalized_url = self._fetch_playlist_data(config.url)
+            station_groups = self._collect_station_groups(data, visited=set([normalized_url]))
+
             self.playlist = PlaylistGenerator(m3uchanneltemplate=config.m3uchanneltemplate)
             self.picons = {}
             self.channels = {}
             m = requests.auth.hashlib.md5()
-            
-            groups = data.get('groups', [])
-            for group in groups:
-                group_name = group.get('name', 'Others')
-                stations = group.get('stations', [])
-                
+
+            for group_name, stations in station_groups:
                 for station in stations:
                     name = station.get('name')
                     url = station.get('url')
@@ -85,7 +133,7 @@ class Af1c1onados(object):
             
             self.etag = '"' + m.hexdigest() + '"'
             self.playlisttime = time.time()
-            self.logger.info('Playlist updated: %d channels in %d groups' % (len(self.channels), len(groups)))
+            self.logger.info('Playlist updated: %d channels in %d groups' % (len(self.channels), len(station_groups)))
             return True
             
         except Exception as e:

--- a/plugins/config/af1c1onados.py
+++ b/plugins/config/af1c1onados.py
@@ -10,6 +10,40 @@ proxies = {}
 # URL for the JSON playlist catalog
 url = 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/AcEStREAM%20iDs.w3u'
 
+# Resolve current subgroup shorteners to raw URLs directly.
+# This avoids VPN/rate-limit issues with cutt.ly/urlfy/n9/smurl.
+urlaliases = {
+    'https://cutt.ly/ctbwFuKv': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/01.%20Dazn.w3u',
+    'https://cutt.ly/TtQOyZkg': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/02.%20EuroSport.w3u',
+    'https://cutt.ly/UtR8TMTN': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/03.%20Dazn%20F1.w3u',
+    'https://urlfy.org/S9KnTq8': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/04.%20Liga%20HyperMotion.w3u',
+    'https://cutt.ly/KtbwJsMV': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/05.0%20Liga%20EA%20Sport.w3u',
+    'https://cutt.ly/MtbwZ4Pk': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/06.%20Liga%20de%20Campeones.w3u',
+    'https://smurl.es/1gXrwn': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/07.%20Movistar%20Plus.w3u',
+    'https://cutt.ly/8tQOtEXz': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/08.%20Movistar%20Deportes.w3u',
+    'https://urlfy.org/SjAtOHH': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/09.%20Movistar.Ellas.w3u',
+    'https://cutt.ly/BtbwCk67': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/10.%20Movistar.Vamos.w3u',
+    'https://n9.cl/zxk3c': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/11.%20ACB.Eventos',
+    'https://smurl.es/1gY6es': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/12.%20Canales%20Espa%C3%B1a.w3u',
+    'https://urlfy.org/IIo5hfE': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/13.%20Copa%20del%20Rey.w3u',
+    'https://cutt.ly/QtbwVXec': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/14.%20Movistar.w3u',
+    'https://smurl.es/1gZm3a': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/15.%20Movistar.Golf.w3u',
+    'https://n9.cl/n4aeay': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/16.%20Tenis%20Channel.w3u',
+    'https://urlfy.org/IzdOsmu': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/17.%20Sport%20TV.w3u',
+    'https://cutt.ly/ntn8ehAC': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/18.%20Ppvp.w3u',
+    'https://cutt.ly/itm87Ku3': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/19.%20Espn.w3u',
+    'https://cutt.ly/Ltn38cB6': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/20.%20BT.Sport.Uk.w3u',
+    'https://urlfy.org/j2Wh47G': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/21.%20Sky.Sport.UK.w3u',
+    'https://cutt.ly/6tn39HDY': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/22.%20Viaplay.Sport.UK.w3u',
+    'https://urlfy.org/h8lfLnx': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/23.%20Bein.Sport.w3u',
+    'https://cutt.ly/Ttn39oLr': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/24.%20Eleven.Sport.w3u',
+    'https://n9.cl/vj46d0': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/25.%20Extreme.Sport.w3u',
+    'https://cutt.ly/wtn8q3vs': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/26.%20EuroSport.360.w3u',
+    'https://smurl.es/1qegGO': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/27.%20Red.Bull.w3u',
+    'https://github.com/af1Series1/Tritolgia/blob/main/28.%20Ufc.w3u': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/main/28.%20Ufc.w3u',
+    'https://cutt.ly/ztn37rRI': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/main/29.%20Nba.USA.w3u',
+}
+
 # Download playlist every N minutes
 updateevery = 60
 

--- a/plugins/config/af1c1onados.py
+++ b/plugins/config/af1c1onados.py
@@ -10,39 +10,8 @@ proxies = {}
 # URL for the JSON playlist catalog
 url = 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/AcEStREAM%20iDs.w3u'
 
-# Resolve current subgroup shorteners to raw URLs directly.
-# This avoids VPN/rate-limit issues with cutt.ly/urlfy/n9/smurl.
-urlaliases = {
-    'https://cutt.ly/ctbwFuKv': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/01.%20Dazn.w3u',
-    'https://cutt.ly/TtQOyZkg': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/02.%20EuroSport.w3u',
-    'https://cutt.ly/UtR8TMTN': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/03.%20Dazn%20F1.w3u',
-    'https://urlfy.org/S9KnTq8': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/04.%20Liga%20HyperMotion.w3u',
-    'https://cutt.ly/KtbwJsMV': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/05.0%20Liga%20EA%20Sport.w3u',
-    'https://cutt.ly/MtbwZ4Pk': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/06.%20Liga%20de%20Campeones.w3u',
-    'https://smurl.es/1gXrwn': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/07.%20Movistar%20Plus.w3u',
-    'https://cutt.ly/8tQOtEXz': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/08.%20Movistar%20Deportes.w3u',
-    'https://urlfy.org/SjAtOHH': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/09.%20Movistar.Ellas.w3u',
-    'https://cutt.ly/BtbwCk67': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/10.%20Movistar.Vamos.w3u',
-    'https://n9.cl/zxk3c': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/11.%20ACB.Eventos',
-    'https://smurl.es/1gY6es': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/12.%20Canales%20Espa%C3%B1a.w3u',
-    'https://urlfy.org/IIo5hfE': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/13.%20Copa%20del%20Rey.w3u',
-    'https://cutt.ly/QtbwVXec': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/14.%20Movistar.w3u',
-    'https://smurl.es/1gZm3a': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/15.%20Movistar.Golf.w3u',
-    'https://n9.cl/n4aeay': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/16.%20Tenis%20Channel.w3u',
-    'https://urlfy.org/IzdOsmu': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/17.%20Sport%20TV.w3u',
-    'https://cutt.ly/ntn8ehAC': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/18.%20Ppvp.w3u',
-    'https://cutt.ly/itm87Ku3': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/19.%20Espn.w3u',
-    'https://cutt.ly/Ltn38cB6': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/20.%20BT.Sport.Uk.w3u',
-    'https://urlfy.org/j2Wh47G': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/21.%20Sky.Sport.UK.w3u',
-    'https://cutt.ly/6tn39HDY': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/22.%20Viaplay.Sport.UK.w3u',
-    'https://urlfy.org/h8lfLnx': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/23.%20Bein.Sport.w3u',
-    'https://cutt.ly/Ttn39oLr': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/24.%20Eleven.Sport.w3u',
-    'https://n9.cl/vj46d0': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/25.%20Extreme.Sport.w3u',
-    'https://cutt.ly/wtn8q3vs': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/26.%20EuroSport.360.w3u',
-    'https://smurl.es/1qegGO': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/27.%20Red.Bull.w3u',
-    'https://github.com/af1Series1/Tritolgia/blob/main/28.%20Ufc.w3u': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/main/28.%20Ufc.w3u',
-    'https://cutt.ly/ztn37rRI': 'https://raw.githubusercontent.com/af1Series1/Tritolgia/main/29.%20Nba.USA.w3u',
-}
+# GitHub tree used as a fallback source when a shortener blocks requests.
+catalogtreeurl = 'https://api.github.com/repos/af1Series1/Tritolgia/git/trees/main?recursive=1'
 
 # Download playlist every N minutes
 updateevery = 60

--- a/plugins/config/af1c1onados.py
+++ b/plugins/config/af1c1onados.py
@@ -7,8 +7,8 @@ import os
 # Proxy settings
 proxies = {}
 
-# URL for the JSON playlist
-url = 'https://af1c1onados.vercel.app/14.AcEStREAM.iDs.w3u'
+# URL for the JSON playlist catalog
+url = 'https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/AcEStREAM%20iDs.w3u'
 
 # Download playlist every N minutes
 updateevery = 60

--- a/plugins/config/newera.py
+++ b/plugins/config/newera.py
@@ -13,7 +13,7 @@ proxies = {}
 
 # Insert your New Era playlist URL here or path to file ('file:///path/to/file' or 'file:///C://path//to//file' for Windows OS)
 # Can be overridden with NEWERA_PLAYLIST_URL environment variable
-url = os.getenv('NEWERA_PLAYLIST_URL', 'https://ipfs.io/ipns/k2k4r8oqlcjxsritt5mczkcn4mmvcmymbqw7113fz2flkrerfwfps004/data/listas/lista_iptv.m3u')
+url = os.getenv('NEWERA_PLAYLIST_URL', 'https://ipfs.io/ipns/k2k4r8lm8tkmuxbc8lkmq1in3v0oya1p6pe9o5bu0hu30br5ko08k2gb/data/listas/lista_iptv.m3u')
 
 # Download playlist every N minutes to keep it fresh
 # 0 = disabled (will download once on startup)


### PR DESCRIPTION
## Summary

This updates the `af1c1onados` plugin to work again after the upstream playlist source changed.

The previous URL now returns `404`:
- `https://af1c1onados.vercel.app/14.AcEStREAM.iDs.w3u`

The current source is:
- `https://raw.githubusercontent.com/af1Series1/Tritolgia/refs/heads/main/AcEStREAM%20iDs.w3u`

## What changed

- update the configured Af1c1onados source URL to the new GitHub raw URL
- support the new catalog structure where the root file exposes `groups[].url` instead of a flat `groups[].stations[]`
- recursively fetch subgroup playlists until station lists are found
- normalize `github.com/.../blob/...` playlist links to `raw.githubusercontent.com/...` so they can be parsed as JSON instead of HTML
- keep duplicate channel name handling unchanged

## Why this is needed

The new Af1c1onados root file is no longer a single playlist with stations directly under each group. It is now a catalog of sub-playlists, so the old parser ends up with empty groups even after the URL is updated.

Without this change, the plugin fails because:
- the old source URL is gone
- the new source structure is hierarchical
- some subgroup links resolve to GitHub `blob` pages unless normalized to `raw`

## Validation

- `py_compile` passes for the updated plugin files
- local Docker test with the patched image returned `200 OK` for `/af1c1onados`
- the generated M3U playlist was served successfully from the updated source
