### PR TITLE
fix(cpp): robust client streaming - resolves issue #6 stream stalls

### DIFF
--- a/httpaceproxycpp/include/httpaceproxycpp/broadcast.hpp
+++ b/httpaceproxycpp/include/httpaceproxycpp/broadcast.hpp
@@ -5,6 +5,7 @@
 #include "httpaceproxycpp/http_client.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <map>
@@ -17,10 +18,16 @@
 
 namespace httpace {
 
+enum class PushResult {
+    Ok,
+    DroppedOldest,
+    Closed,
+};
+
 class ChunkQueue {
 public:
     explicit ChunkQueue(std::size_t max_chunks);
-    bool push(std::vector<char> chunk);
+    PushResult push(std::vector<char> chunk, std::chrono::milliseconds wait);
     bool pop(std::vector<char>& chunk);
     void close();
     std::size_t size() const;
@@ -28,7 +35,8 @@ public:
 private:
     std::size_t max_chunks_;
     mutable std::mutex mutex_;
-    std::condition_variable cv_;
+    std::condition_variable cv_data_;
+    std::condition_variable cv_space_;
     std::deque<std::vector<char>> chunks_;
     bool closed_ = false;
 };
@@ -41,6 +49,9 @@ struct StreamClient {
     std::int64_t connection_time = 0;
     std::shared_ptr<ChunkQueue> queue;
     std::weak_ptr<AceClient> ace;
+    std::atomic<std::int64_t> last_activity{0};
+    std::atomic<int> dropped_chunks{0};
+    std::atomic<bool> stuck_logged{false};
 };
 
 class Broadcast : public std::enable_shared_from_this<Broadcast> {
@@ -75,6 +86,7 @@ private:
     std::vector<std::weak_ptr<StreamClient>> clients_;
     std::atomic<bool> running_{false};
     std::atomic<bool> started_{false};
+    std::atomic<bool> stopped_{false};
     std::thread stream_thread_;
 };
 

--- a/httpaceproxycpp/include/httpaceproxycpp/config.hpp
+++ b/httpaceproxycpp/include/httpaceproxycpp/config.hpp
@@ -19,6 +19,9 @@ struct Config {
     int ace_result_timeout = 5;
     int video_timeout = 30;
     int video_seekback = 0;
+    int client_queue_size = 256;
+    int client_write_timeout = 15;
+    int curl_stream_buffer = 1048576;
     bool use_chunked = true;
     bool firewall = false;
     bool firewall_blacklist_mode = false;

--- a/httpaceproxycpp/include/httpaceproxycpp/http_client.hpp
+++ b/httpaceproxycpp/include/httpaceproxycpp/http_client.hpp
@@ -28,7 +28,8 @@ public:
                 const std::function<bool(const char*, std::size_t)>& on_chunk,
                 const std::atomic<bool>& cancel,
                 long connect_timeout_seconds,
-                long read_timeout_seconds) const;
+                long read_timeout_seconds,
+                long buffer_size = 1048576) const;
 };
 
 } // namespace httpace

--- a/httpaceproxycpp/include/httpaceproxycpp/http_server.hpp
+++ b/httpaceproxycpp/include/httpaceproxycpp/http_server.hpp
@@ -62,6 +62,7 @@ public:
     void start();
     void stop();
     void join();
+    void set_client_send_timeout(int seconds) { client_send_timeout_ = seconds; }
 
 private:
     void accept_loop();
@@ -71,6 +72,7 @@ private:
     int port_;
     HttpHandler handler_;
     int listen_fd_ = -1;
+    int client_send_timeout_ = 0;
     std::atomic<bool> running_{false};
     std::thread accept_thread_;
 };

--- a/httpaceproxycpp/src/broadcast.cpp
+++ b/httpaceproxycpp/src/broadcast.cpp
@@ -8,30 +8,42 @@
 
 namespace httpace {
 
-ChunkQueue::ChunkQueue(std::size_t max_chunks) : max_chunks_(max_chunks) {}
+ChunkQueue::ChunkQueue(std::size_t max_chunks) : max_chunks_(std::max<std::size_t>(2, max_chunks)) {}
 
-bool ChunkQueue::push(std::vector<char> chunk) {
+PushResult ChunkQueue::push(std::vector<char> chunk, std::chrono::milliseconds wait) {
     std::unique_lock<std::mutex> lock(mutex_);
-    if (closed_) return false;
-    if (chunks_.size() >= max_chunks_) return false;
+    if (closed_) return PushResult::Closed;
+    if (chunks_.size() >= max_chunks_ && wait.count() > 0) {
+        cv_space_.wait_for(lock, wait, [&] {
+            return closed_ || chunks_.size() < max_chunks_;
+        });
+        if (closed_) return PushResult::Closed;
+    }
+    PushResult result = PushResult::Ok;
+    if (chunks_.size() >= max_chunks_) {
+        chunks_.pop_front();
+        result = PushResult::DroppedOldest;
+    }
     chunks_.push_back(std::move(chunk));
-    cv_.notify_one();
-    return true;
+    cv_data_.notify_one();
+    return result;
 }
 
 bool ChunkQueue::pop(std::vector<char>& chunk) {
     std::unique_lock<std::mutex> lock(mutex_);
-    cv_.wait(lock, [&] { return closed_ || !chunks_.empty(); });
+    cv_data_.wait(lock, [&] { return closed_ || !chunks_.empty(); });
     if (chunks_.empty()) return false;
     chunk = std::move(chunks_.front());
     chunks_.pop_front();
+    cv_space_.notify_one();
     return true;
 }
 
 void ChunkQueue::close() {
     std::lock_guard<std::mutex> lock(mutex_);
     closed_ = true;
-    cv_.notify_all();
+    cv_data_.notify_all();
+    cv_space_.notify_all();
 }
 
 std::size_t ChunkQueue::size() const {
@@ -60,7 +72,8 @@ std::shared_ptr<StreamClient> Broadcast::add_client(const std::string& client_ip
     client->channel_name = channel_name;
     client->channel_icon = channel_icon.empty() ? "http://static.acestream.net/sites/acestream/img/ACE-logo.png" : channel_icon;
     client->connection_time = unix_time();
-    client->queue = std::make_shared<ChunkQueue>(static_cast<std::size_t>(std::max(2, config_.video_timeout)));
+    client->last_activity = client->connection_time;
+    client->queue = std::make_shared<ChunkQueue>(static_cast<std::size_t>(std::max(2, config_.client_queue_size)));
     client->ace = ace_;
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -107,11 +120,13 @@ void Broadcast::start_once() {
 }
 
 void Broadcast::stop() {
+    bool expected = false;
+    if (!stopped_.compare_exchange_strong(expected, true)) return;
     running_ = false;
     for (auto& client : clients()) client->queue->close();
     if (ace_) {
-        ace_->stop_broadcast();
-        ace_->shutdown();
+        try { ace_->stop_broadcast(); } catch (...) {}
+        try { ace_->shutdown(); } catch (...) {}
     }
     if (stream_thread_.joinable() && stream_thread_.get_id() != std::this_thread::get_id()) stream_thread_.join();
 }
@@ -134,7 +149,7 @@ void Broadcast::stream_http_url(const std::string& url) {
     http_client_.stream(url, [&](const char* data, std::size_t size) {
         broadcast_chunk(data, size);
         return running_ && client_count() > 0;
-    }, running_, 5, config_.video_timeout);
+    }, running_, 5, config_.video_timeout, std::max(1, config_.curl_stream_buffer));
 }
 
 void Broadcast::stream_hls_url(const std::string& url) {
@@ -168,10 +183,24 @@ void Broadcast::stream_hls_url(const std::string& url) {
 
 void Broadcast::broadcast_chunk(const char* data, std::size_t size) {
     std::vector<char> chunk(data, data + size);
+    auto write_timeout = std::max(1, config_.client_write_timeout);
+    auto wait = std::chrono::milliseconds(write_timeout * 1000 / 4);
+    auto now = unix_time();
     for (auto& client : clients()) {
-        if (!client->queue->push(chunk)) {
-            log_line("WARNING", "[" + client->client_ip + "] client queue full, closing client");
-            client->queue->close();
+        auto result = client->queue->push(chunk, wait);
+        if (result == PushResult::Closed) continue;
+        if (result == PushResult::DroppedOldest) {
+            client->dropped_chunks.fetch_add(1, std::memory_order_relaxed);
+            if (now - client->last_activity.load() > write_timeout) {
+                if (!client->stuck_logged.exchange(true)) {
+                    log_line("WARNING", "[" + client->client_ip + "] client too slow ("
+                             + std::to_string(client->dropped_chunks.load()) + " chunks dropped in "
+                             + std::to_string(write_timeout) + "s), closing");
+                    client->queue->close();
+                }
+            }
+        } else {
+            client->dropped_chunks.store(0, std::memory_order_relaxed);
         }
     }
 }

--- a/httpaceproxycpp/src/config.cpp
+++ b/httpaceproxycpp/src/config.cpp
@@ -69,6 +69,9 @@ Config load_config(int argc, char** argv) {
     cfg.ace_result_timeout = getenv_int("ACE_RESULT_TIMEOUT", cfg.ace_result_timeout);
     cfg.video_timeout = getenv_int("VIDEO_TIMEOUT", cfg.video_timeout);
     cfg.video_seekback = getenv_int("VIDEO_SEEKBACK", cfg.video_seekback);
+    cfg.client_queue_size = getenv_int("CLIENT_QUEUE_SIZE", cfg.client_queue_size);
+    cfg.client_write_timeout = getenv_int("CLIENT_WRITE_TIMEOUT", cfg.client_write_timeout);
+    cfg.curl_stream_buffer = getenv_int("CURL_STREAM_BUFFER", cfg.curl_stream_buffer);
 
     if (argc > 0 && argv && argv[0]) {
         std::filesystem::path exe(argv[0]);

--- a/httpaceproxycpp/src/http_client.cpp
+++ b/httpaceproxycpp/src/http_client.cpp
@@ -101,7 +101,8 @@ bool HttpClient::stream(const std::string& url,
                         const std::function<bool(const char*, std::size_t)>& on_chunk,
                         const std::atomic<bool>& cancel,
                         long connect_timeout_seconds,
-                        long read_timeout_seconds) const {
+                        long read_timeout_seconds,
+                        long buffer_size) const {
     CURL* curl = curl_easy_init();
     if (!curl) return false;
     StreamState state{&on_chunk, &cancel};
@@ -118,6 +119,7 @@ bool HttpClient::stream(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
     curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "HTTPAceProxyCPP");
+    curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, static_cast<long>(buffer_size));
     CURLcode rc = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
     return rc == CURLE_OK || !cancel.load();

--- a/httpaceproxycpp/src/http_server.cpp
+++ b/httpaceproxycpp/src/http_server.cpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -139,6 +140,10 @@ void HttpServer::accept_loop() {
         }
         char ip[INET_ADDRSTRLEN] = {0};
         ::inet_ntop(AF_INET, &client.sin_addr, ip, sizeof(ip));
+        if (client_send_timeout_ > 0) {
+            timeval tv{client_send_timeout_, 0};
+            ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+        }
         std::thread(&HttpServer::handle_client, this, fd, std::string(ip)).detach();
     }
 }

--- a/httpaceproxycpp/src/proxy.cpp
+++ b/httpaceproxycpp/src/proxy.cpp
@@ -152,6 +152,7 @@ Proxy::~Proxy() { stop(); }
 void Proxy::start() {
     server_ = std::make_unique<HttpServer>(config_.http_host, config_.http_port,
         [this](const HttpRequest& request, ClientConnection& connection) { handle_http(request, connection); });
+    server_->set_client_send_timeout(config_.client_write_timeout);
     server_->start();
     log_line("INFO", "HTTPAceProxyCPP started at " + config_.http_host + ":" + std::to_string(config_.http_port));
     server_->join();
@@ -309,15 +310,18 @@ void Proxy::handle_core_stream(RequestContext& ctx) {
 
         std::vector<char> chunk;
         while (client->queue->pop(chunk)) {
+            bool ok;
             if (chunked) {
                 std::ostringstream prefix;
                 prefix << std::hex << chunk.size() << "\r\n";
-                if (!ctx.connection.send_text(prefix.str())) break;
-                if (!ctx.connection.send_all(chunk.data(), chunk.size())) break;
-                if (!ctx.connection.send_text("\r\n")) break;
+                ok = ctx.connection.send_text(prefix.str())
+                  && ctx.connection.send_all(chunk.data(), chunk.size())
+                  && ctx.connection.send_text("\r\n");
             } else {
-                if (!ctx.connection.send_all(chunk.data(), chunk.size())) break;
+                ok = ctx.connection.send_all(chunk.data(), chunk.size());
             }
+            if (!ok) break;
+            client->last_activity.store(unix_time(), std::memory_order_relaxed);
         }
         if (chunked) ctx.connection.send_text("0\r\n\r\n");
         broadcast->remove_client(client);


### PR DESCRIPTION
Streams were dropped within seconds in v4.0.0 because the per-client chunk queue was sized as max(2, video_timeout) = 30 entries, and curl delivered ~16 KB chunks, giving an effective buffer of ~480 KB (vs ~30 MB in the Python version with chunk_size=1 MB). Any prebuffer burst from AceStream filled the queue instantly and the proxy closed the client on the very first overflow. STOP/SHUTDOWN were also emitted multiple times because Broadcast::stop was non-idempotent.

Changes:

- Decouple buffer size from video_timeout. Add CLIENT_QUEUE_SIZE (default 256), CLIENT_WRITE_TIMEOUT (default 15s) and CURL_STREAM_BUFFER (default 1 MiB) env knobs.
- ChunkQueue::push now waits up to a configurable timeout for free space and falls back to drop-oldest instead of fail-fast. Add a cv_space_ condvar notified on pop so producer can resume.
- Track per-client last_activity, dropped_chunks counter, and a one-shot stuck_logged flag. Only close the client (and log once) when the consumer has not progressed for client_write_timeout seconds while drops keep happening - silences the warning storm.
- Make Broadcast::stop idempotent via a stopped_ flag, so the engine STOP/SHUTDOWN messages are emitted only once even when several clients tear down concurrently.
- Increase libcurl read buffer for streaming to CURL_STREAM_BUFFER (1 MiB by default) to mirror the Python iter_content size and reduce the rate of broadcast_chunk invocations.
- Apply SO_SNDTIMEO on each accepted client socket so a hung TCP consumer is detected by send() instead of by queue overflow.

Built with cmake, all tests pass.